### PR TITLE
Hotfix/1128

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
 	"id": "tab-flow",
 	"name": "Tab Flow",
-	"version": "0.3.7",
+	"version": "0.3.8",
 	"minAppVersion": "1.8.0",
 	"description": "Render, play and write guitar tabs. Support guitar pro(gtp) files(.gp, .gp3, .gp4, .gp5, .gpx), write scores in alphaTex (.atex).",
 	"author": "Jay Bridge",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "obsidian-tab-flow",
-	"version": "0.3.7",
+	"version": "0.3.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "obsidian-tab-flow",
-			"version": "0.3.7",
+			"version": "0.3.8",
 			"license": "MPL-2.0",
 			"dependencies": {
 				"@codemirror/commands": "^6.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "obsidian-tab-flow",
-	"version": "0.3.7",
+	"version": "0.3.8",
 	"description": "",
 	"main": "main.js",
 	"type": "module",

--- a/src/components/EditorBar.ts
+++ b/src/components/EditorBar.ts
@@ -746,7 +746,9 @@ export function createEditorBar(options: EditorBarOptions): HTMLDivElement {
 	}
 
 	const originalRemove = bar.remove.bind(bar);
-	bar.remove = function (this: void) {
+	// Use arrow function to avoid unintentional `this` scoping when the method
+	// is referenced separately from the element.
+	bar.remove = () => {
 		originalRemove();
 	};
 

--- a/src/components/ExportChooserModal.ts
+++ b/src/components/ExportChooserModal.ts
@@ -100,9 +100,9 @@ export class ExportChooserModal extends Modal {
 					this.eventBus.subscribe('状态:音频导出失败', failHandler);
 					this.eventBus.publish('命令:导出音频', { fileName: chosenName });
 					this.close();
-					} catch (e) {
-						new Notice(t('export.exportStartFailed') + ': ' + formatError(e));
-					}
+				} catch (e) {
+					new Notice(t('export.exportStartFailed') + ': ' + formatError(e));
+				}
 			})();
 		};
 

--- a/src/components/ExportChooserModal.ts
+++ b/src/components/ExportChooserModal.ts
@@ -1,5 +1,6 @@
 import { App, Modal, Notice } from 'obsidian';
 import { t } from '../i18n';
+import { formatError } from '../utils/errorUtils';
 
 export interface ExportChooserOptions {
 	app: App;
@@ -78,20 +79,7 @@ export class ExportChooserModal extends Modal {
 						}
 					};
 					const failHandler = (err?: unknown) => {
-						let errMsg = '';
-						if (err instanceof Error) {
-							errMsg = err.message;
-						} else if (err) {
-							if (typeof err === 'string') {
-								errMsg = err;
-							} else {
-								try {
-									errMsg = JSON.stringify(err);
-								} catch {
-									errMsg = String(err);
-								}
-							}
-						}
+						const errMsg = formatError(err);
 						if (errMsg) {
 							new Notice(t('export.audioExportFailedWithError', { error: errMsg }));
 						} else {
@@ -112,9 +100,9 @@ export class ExportChooserModal extends Modal {
 					this.eventBus.subscribe('状态:音频导出失败', failHandler);
 					this.eventBus.publish('命令:导出音频', { fileName: chosenName });
 					this.close();
-				} catch (e) {
-					new Notice(t('export.exportStartFailed') + ': ' + e);
-				}
+					} catch (e) {
+						new Notice(t('export.exportStartFailed') + ': ' + formatError(e));
+					}
 			})();
 		};
 
@@ -126,7 +114,7 @@ export class ExportChooserModal extends Modal {
 				this.eventBus.publish('命令:导出MIDI', { fileName: chosenName });
 				this.close();
 			} catch (e) {
-				new Notice(t('export.midiExportFailed') + ': ' + e);
+				new Notice(t('export.midiExportFailed') + ': ' + formatError(e));
 			}
 		};
 
@@ -138,7 +126,7 @@ export class ExportChooserModal extends Modal {
 				this.eventBus.publish('命令:导出PDF', { fileName: chosenName });
 				this.close();
 			} catch (e) {
-				new Notice(t('export.pdfExportFailed') + ': ' + e);
+				new Notice(t('export.pdfExportFailed') + ': ' + formatError(e));
 			}
 		};
 
@@ -150,7 +138,7 @@ export class ExportChooserModal extends Modal {
 				this.eventBus.publish('命令:导出GP', { fileName: chosenName });
 				this.close();
 			} catch (e) {
-				new Notice(t('export.gpExportFailed') + ': ' + e);
+				new Notice(t('export.gpExportFailed') + ': ' + formatError(e));
 			}
 		};
 	}

--- a/src/components/PlayBar.ts
+++ b/src/components/PlayBar.ts
@@ -608,7 +608,10 @@ export function createPlayBar(options: PlayBarOptions): HTMLDivElement {
 	}
 
 	const originalRemove = bar.remove.bind(bar);
-	bar.remove = function (this: void) {
+	// Use arrow function to avoid unintentional `this` scoping when the method
+	// is referenced separately from the element. Arrow functions capture lexical
+	// `this` and do not create their own `this` context.
+	bar.remove = () => {
 		originalRemove();
 	};
 

--- a/src/settings/tabs/editorTab.ts
+++ b/src/settings/tabs/editorTab.ts
@@ -590,7 +590,8 @@ export function renderEditorTab(
 						);
 					} catch (e) {
 						new Notice(
-							t('settings.editor.resetToDefaultFailed', undefined, '重置失败: ') + formatError(e)
+							t('settings.editor.resetToDefaultFailed', undefined, '重置失败: ') +
+								formatError(e)
 						);
 					}
 				}

--- a/src/settings/tabs/editorTab.ts
+++ b/src/settings/tabs/editorTab.ts
@@ -2,6 +2,7 @@ import { App, Notice, Setting, TextComponent, DropdownComponent } from 'obsidian
 import { setIcon } from 'obsidian';
 import TabFlowPlugin from '../../main';
 import { t } from '../../i18n';
+import { formatError } from '../../utils/errorUtils';
 import { DEFAULT_SETTINGS, EditorBarComponentVisibility } from '../defaults';
 import {
 	createEmbeddableMarkdownEditor,
@@ -511,7 +512,7 @@ export function renderEditorTab(
 								'settings.editor.resetHighlightToDefaultFailed',
 								undefined,
 								'重置失败: '
-							) + e
+							) + formatError(e)
 						);
 					}
 				});
@@ -589,7 +590,7 @@ export function renderEditorTab(
 						);
 					} catch (e) {
 						new Notice(
-							t('settings.editor.resetToDefaultFailed', undefined, '重置失败: ') + e
+							t('settings.editor.resetToDefaultFailed', undefined, '重置失败: ') + formatError(e)
 						);
 					}
 				}

--- a/src/settings/tabs/generalTab.ts
+++ b/src/settings/tabs/generalTab.ts
@@ -4,6 +4,7 @@ import { ASSET_FILES } from '../../services/ResourceLoaderService';
 import { vaultPath } from '../../utils';
 import { AssetStatus } from '../../types/assets';
 import { t } from '../../i18n';
+import { formatError } from '../../utils/errorUtils';
 import path from 'path';
 // @ts-ignore
 import { shell } from 'electron';
@@ -177,7 +178,7 @@ export async function renderGeneralTab(
 			// @ts-ignore
 			shell.showItemInFolder(mainJsPath);
 		} catch (e) {
-			new Notice(t('assetManagement.openDirFailed') + e);
+			new Notice(t('assetManagement.openDirFailed') + ': ' + formatError(e));
 		}
 	};
 

--- a/src/settings/tabs/playerTab.ts
+++ b/src/settings/tabs/playerTab.ts
@@ -3,6 +3,7 @@ import TabFlowPlugin from '../../main';
 import { setIcon } from 'obsidian';
 import { DEFAULT_SETTINGS, PlayBarComponentVisibility } from '../defaults';
 import { t } from '../../i18n';
+import { formatError } from '../../utils/errorUtils';
 
 export function renderPlayerTab(
 	tabContents: HTMLElement,
@@ -34,7 +35,7 @@ export function renderPlayerTab(
 					}
 					new Notice(t('settings.player.resetToDefaultSuccess'));
 				} catch (e) {
-					new Notice(t('settings.player.resetToDefaultFailed') + ': ' + e);
+					new Notice(t('settings.player.resetToDefaultFailed') + ': ' + formatError(e));
 				}
 			});
 		});


### PR DESCRIPTION
> Thank you for your submission, an automated scan of your plugin code's revealed the following issues:
> 
> ### Required
> [[1]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/components/EditorBar.ts#L748-L748)[[2]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/components/PlayBar.ts#L610-L610) A method that is not declared with `this: void` may cause unintentional scoping of `this` when separated from its object. Consider using an arrow function or explicitly `.bind()`ing the method to avoid calling the method with an unintended `this` value. If a function does not access `this`, it can be annotated with `this: void`.
> 
> [[1]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/components/ExportChooserModal.ts#L81-L81) 'err' will use Object's default stringification format ('[object Object]') when stringified.
> 
> [[1]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/markdown/AlphaTexBlock.ts#L739-L739)[[2]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/settings/tabs/editorTab.ts#L342-L342)[[3]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/settings/tabs/editorTab.ts#L345-L345)[[4]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/DocView.ts#L183-L183)[[5]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/TabView.ts#L278-L278)[[6]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/BarMetadata.ts#L32-L32)[[7]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/BeatEffects.ts#L42-L42)[[8]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/ExampleProgression.ts#L33-L33)[[9]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/ExampleProgression.ts#L34-L34)[[10]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/ExampleProgression.ts#L37-L37)[[11]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/ExampleProgression.ts#L39-L39)[[12]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/InMarkdownRender.ts#L14-L14)[[13]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/InstrumentsTuning.ts#L20-L20)[[14]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/InstrumentsTuning.ts#L26-L26)[[15]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/InstrumentsTuning.ts#L30-L30)[[16]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/InstrumentsTuning.ts#L33-L33)[[17]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/InstrumentsTuning.ts#L36-L36)[[18]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Lyrics.ts#L14-L14)[[19]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Metadata.ts#L32-L32)[[20]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Metadata.ts#L42-L42)[[21]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Metadata.ts#L44-L44)[[22]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Metadata.ts#L46-L46)[[23]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/NoteEffects.ts#L55-L55)[[24]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Notes.ts#L48-L48)[[25]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Notes.ts#L54-L54)[[26]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Notes.ts#L80-L80)[[27]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Notes.ts#L90-L90)[[28]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Notes.ts#L100-L100)[[29]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Notes.ts#L110-L110)[[30]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Overview.ts#L19-L19)[[31]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Overview.ts#L23-L23)[[32]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Overview.ts#L25-L25)[[33]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Overview.ts#L29-L29)[[34]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Overview.ts#L32-L32)[[35]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Overview.ts#L35-L35)[[36]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Overview.ts#L38-L38)[[37]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Percussion.ts#L144-L144)[[38]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Percussion.ts#L178-L178)[[39]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/ReadMe.ts#L3-L3)[[40]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/SimpleTabify.ts#L4-L4)[[41]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/SimpleTabify.ts#L14-L14)[[42]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/SimpleTabify.ts#L20-L20)[[43]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/SimpleTabify.ts#L45-L45)[[44]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/Stylesheet.ts#L42-L42)[[45]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/SyncPoints.ts#L3-L3)[[46]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/en/SyncPoints.ts#L9-L9)[[47]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/BarMetadata.ts#L38-L38)[[48]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/ExampleProgression.ts#L39-L39)[[49]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/InstrumentsTuning.ts#L24-L24)[[50]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/InstrumentsTuning.ts#L26-L26)[[51]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/InstrumentsTuning.ts#L30-L30)[[52]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/InstrumentsTuning.ts#L33-L33)[[53]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/InstrumentsTuning.ts#L36-L36)[[54]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/Metadata.ts#L38-L38)[[55]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/Metadata.ts#L44-L44)[[56]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/Metadata.ts#L46-L46)[[57]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/Metadata.ts#L48-L48)[[58]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/Notes.ts#L54-L54)[[59]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/Notes.ts#L78-L78)[[60]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/Notes.ts#L80-L80)[[61]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/Notes.ts#L89-L89)[[62]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/Notes.ts#L98-L98)[[63]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/Notes.ts#L108-L108)[[64]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/Overview.ts#L23-L23)[[65]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/Overview.ts#L25-L25)[[66]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/Overview.ts#L34-L34)[[67]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/Percussion.ts#L178-L178)[[68]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/ReadMe.ts#L7-L7)[[69]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/SimpleTabify.ts#L14-L14)[[70]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/SimpleTabify.ts#L20-L20)[[71]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/SimpleTabify.ts#L45-L45)[[72]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/Stylesheet.ts#L51-L51)[[73]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/Stylesheet.ts#L64-L64)[[74]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/Stylesheet.ts#L74-L74)[[75]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/Stylesheet.ts#L87-L87)[[76]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/docs/zh/SyncPoints.ts#L9-L9) Use sentence case for UI text.
> 
> ### Optional
> [[1]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/components/AlphaTexPlayground.ts#L363-L363)[[2]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/components/AlphaTexPlayground.ts#L393-L393)[[3]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/components/AlphaTexPlayground.ts#L502-L502)[[4]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/components/AlphaTexPlayground.ts#L520-L520)[[5]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/components/ShareCardModal.ts#L556-L556)[[6]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/components/ShareCardModal.ts#L730-L730)[[7]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/components/ShareCardModal.ts#L762-L762)[[8]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/components/ShareCardModal.ts#L1062-L1062)[[9]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/components/ShareCardModal.ts#L1067-L1067)[[10]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/components/ShareCardModal.ts#L1077-L1077)[[11]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/components/ShareCardPreview.ts#L22-L22)[[12]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/main.ts#L317-L317)[[13]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/services/ShareCardPresetService.ts#L62-L62)[[14]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/utils/shareCardUtils.ts#L51-L51)[[15]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/utils/shareCardUtils.ts#L93-L93)[[16]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/utils/stringUtils.ts#L10-L10)[[17]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/utils/stringUtils.ts#L15-L15)[[18]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/utils/tabViewHelpers.ts#L15-L15)[[19]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/utils/tabViewHelpers.ts#L22-L22)[[20]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/DocView.ts#L220-L220)[[21]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/DocView.ts#L272-L272)[[22]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/EditorView.ts#L49-L49)[[23]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/EditorView.ts#L236-L236)[[24]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/EditorView.ts#L259-L259)[[25]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/EditorView.ts#L269-L269)[[26]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/EditorView.ts#L279-L279)[[27]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/EditorView.ts#L446-L446)[[28]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/EditorView.ts#L473-L473)[[29]](https://github.com/LIUBINfighter/Obsidian-Tab-Flow/blob/f848c59edbfcb96533a13563b76752576b80ec87/src/views/TabView.ts#L563-L563) '_' is defined but never used.
> 
> Do NOT open a new PR for re-validation. Once you have pushed some changes to your repository the bot will rescan within 6 hours If you think some of the required changes are incorrect, please comment with `/skip` and the reason why you think the results are incorrect. To run these checks locally, install the [eslint plugin](https://github.com/obsidianmd/eslint-plugin) in your project. Do NOT rebase this PR, this will be handled by the reviewer once the plugin has been approved.

